### PR TITLE
Implement Google OAuth 2.0 login

### DIFF
--- a/src/auth/google.ts
+++ b/src/auth/google.ts
@@ -1,0 +1,38 @@
+import passport from 'passport';
+import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
+
+/**
+ * Configures Passport with Google OAuth 2.0 strategy.
+ */
+export function configureGoogleStrategy(): void {
+  const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_CALLBACK_URL } = process.env;
+
+  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !GOOGLE_CALLBACK_URL) {
+    throw new Error('Missing Google OAuth environment variables');
+  }
+
+  // Use the Google strategy with profile and email scopes
+  passport.use(
+    new GoogleStrategy(
+      {
+        clientID: GOOGLE_CLIENT_ID,
+        clientSecret: GOOGLE_CLIENT_SECRET,
+        callbackURL: GOOGLE_CALLBACK_URL,
+      },
+      // Verification callback simply passes the profile forward
+      (_accessToken, _refreshToken, profile, done) => {
+        return done(null, profile);
+      }
+    )
+  );
+
+  // Serialize the entire user object into the session
+  passport.serializeUser((user, done) => {
+    done(null, user);
+  });
+
+  // Deserialize the user object from the session
+  passport.deserializeUser((obj: Express.User, done) => {
+    done(null, obj);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,36 @@
+import express from 'express';
+import session from 'express-session';
+import passport from 'passport';
+import dotenv from 'dotenv';
+
+import authRouter from './routes/auth';
+import { configureGoogleStrategy } from './auth/google';
+
+// Load environment variables from .env file
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Configure session middleware with a secure secret
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || 'change_this_secret',
+    resave: false,
+    saveUninitialized: false,
+  })
+);
+
+// Initialize Passport and session handling
+configureGoogleStrategy();
+app.use(passport.initialize());
+app.use(passport.session());
+
+// Mount authentication routes
+app.use('/auth', authRouter);
+
+// Start the server
+app.listen(PORT, () => {
+  console.log(`Servidor escuchando en el puerto ${PORT}`);
+  console.log('Las rutas /auth/google y /auth/google/callback están listas');
+});

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,0 +1,34 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import passport from 'passport';
+
+// Router that exposes authentication endpoints
+const router = Router();
+
+// Redirects the user to Google for authentication
+router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+
+// Handles the callback from Google after authentication
+router.get(
+  '/google/callback',
+  passport.authenticate('google', { failureRedirect: '/auth/failure' }),
+  (req: Request, res: Response) => {
+    // On success, redirect back to the frontend with a query parameter
+    const redirectUrl = `${process.env.FRONTEND_URL}?auth=success`;
+    res.redirect(redirectUrl);
+  }
+);
+
+// Returns the currently authenticated user or null
+router.get('/current-user', (req: Request, res: Response) => {
+  res.json(req.user || null);
+});
+
+// Logs out the user and redirects to the frontend
+router.get('/logout', (req: Request, res: Response, next: NextFunction) => {
+  req.logout((err) => {
+    if (err) return next(err);
+    res.redirect(process.env.FRONTEND_URL || '/');
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add Google passport strategy setup
- expose auth routes for Google login
- configure express-session and passport in server index

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685420e6e80883208076eebfaeaa9ce4